### PR TITLE
bump version of `anti-phish-advanced`

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/schielef/Xilot#readme",
   "dependencies": {
        	"@discordjs/builders": "^0.9.0",
-        "anti-phish-advanced": "^1.0.5",
+        "anti-phish-advanced": "^1.0.9",
         "axios": "^0.24.0",
         "canvas": "^2.8.0",
         "discord-giveaways": "^5.0.1",


### PR DESCRIPTION
Bumped up version of the `anti-phish-advanced` package from `1.0.5` to `1.0.9` since it includes bug fixes to unknown bugs in `1.0.5`

*apologies for the amount of PRs*